### PR TITLE
Fixed not as recomended

### DIFF
--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -234,7 +234,7 @@ compiler:
     viaIR: true
     optimizer:
       enabled: true
-      runs: 2400
+      runs: 200
     remappings: 
       - "@chainlink=smartcontractkit/chainlink@1.1.0"
       - "@OpenZeppelin=OpenZeppelin/openzeppelin-contracts@4.8.0"

--- a/contracts/NftBattleArena.sol
+++ b/contracts/NftBattleArena.sol
@@ -367,7 +367,8 @@ contract NftBattleArena
 
 		updateInfo(stakingPositionId);                                                          // Updates staking position params from previous epochs.
 
-		dai.approve(address(vault), type(uint256).max);                                         // Approves Dai for yearn.
+		if (dai.allowance(address(this), address(vault)) < amount)
+			dai.approve(address(vault), type(uint256).max);                                         // Approves Dai for yearn.
 		uint256 yTokensNumber = vault.balanceOf(address(this));
 		require(vault.mint(amount) == 0);                                                       // Deposits dai to yearn vault and get yTokens.
 


### PR DESCRIPTION
Approve was not moved to constructor, becuase we need approves for cases, when allowance was decreased by attacker. Added allowance condition.